### PR TITLE
feat: campaign/character/roll commands must be run in channels

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,7 +59,7 @@ repos:
             entry: yamllint --strict --config-file .yamllint.yml
 
     - repo: "https://github.com/charliermarsh/ruff-pre-commit"
-      rev: "v0.4.9"
+      rev: "v0.4.10"
       hooks:
           - id: ruff
             args: ["--extend-ignore", "I001,D301,D401"]

--- a/TODO.md
+++ b/TODO.md
@@ -15,6 +15,7 @@
 -   [ ] Statistics: Track per book stats
 -   [ ] Statistics: Track per campaign stats
 -   [ ] Storyteller: Add notes
+-   [ ] Storyteller: Associate storyteller characters with campaigns
 -   [ ] Tests: Increase coverage
 -   [x] Campaign: Add books to campaigns. Books contain chapters.
 -   [x] Campaign: Associate characters with campaigns

--- a/TODO.md
+++ b/TODO.md
@@ -9,12 +9,13 @@
 -   [ ] CharGen: Adjust hunter virtues according to this: Virtues are awarded to or imposed upon your character when she is imbued. You have three starting points to spend in any of the Virtues. However, your rating in your character's "creed Virtue" - her primary Virtue - cannot be exceeded by her score in any other Virtue. Thus, a Defender's Zeal rating cannot be exceeded by her Vision or Mercy ratings - she could have 3 Zeal; 2 Zeal, 1 Vision and 0 Mercy; or one point in each. Likewise, a Redeemer's Mercy cannot be exceeded by her Zeal or Vision ratings.
 -   [ ] Database: On bot load, poll all character traits and update `custom` status and max value for traits in enums. This will keep database in-sync with the codebase.
 -   [ ] Gameplay: Button to create macro from rolling traits
+-   [ ] Notes: Add/Edit/View individual player notes
 -   [ ] Refactor: Move testable logic out of cogs and to services or db models
 -   [ ] Statistics: Pull stats based on timeframe
 -   [ ] Statistics: Track per book stats
+-   [ ] Statistics: Track per campaign stats
 -   [ ] Storyteller: Add notes
 -   [ ] Tests: Increase coverage
--   [ ] Notes: View individual player notes
 -   [x] Campaign: Add books to campaigns. Books contain chapters.
 -   [x] Campaign: Associate characters with campaigns
 -   [x] Campaign: create channels for each character

--- a/poetry.lock
+++ b/poetry.lock
@@ -208,17 +208,17 @@ test = ["asgi-lifespan (>=1.0.1)", "dnspython (>=2.1.0)", "fastapi (>=0.100)", "
 
 [[package]]
 name = "boto3"
-version = "1.34.130"
+version = "1.34.131"
 description = "The AWS SDK for Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "boto3-1.34.130-py3-none-any.whl", hash = "sha256:c163fb7135a94e7b8c8c478a44071c843f05e212fa4bec3105f8a437ecbf1bcb"},
-    {file = "boto3-1.34.130.tar.gz", hash = "sha256:b781d267dd5e7583966e05697f6bd45e2f46c01dc619ba0860b042963ee69296"},
+    {file = "boto3-1.34.131-py3-none-any.whl", hash = "sha256:05e388cb937e82be70bfd7eb0c84cf8011ff35cf582a593873ac21675268683b"},
+    {file = "boto3-1.34.131.tar.gz", hash = "sha256:dab8f72a6c4e62b4fd70da09e08a6b2a65ea2115b27dd63737142005776ef216"},
 ]
 
 [package.dependencies]
-botocore = ">=1.34.130,<1.35.0"
+botocore = ">=1.34.131,<1.35.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.10.0,<0.11.0"
 
@@ -227,13 +227,13 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.34.130"
+version = "1.34.131"
 description = "Low-level, data-driven core of boto 3."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "botocore-1.34.130-py3-none-any.whl", hash = "sha256:a3b36e9dac1ed31c4cb3a5c5e540a7d8a9b90ff1d17f87734e674154b41776d8"},
-    {file = "botocore-1.34.130.tar.gz", hash = "sha256:a242b3b0a836b14f308a309565cd63e88654cec238f9b73abbbd3c0526db4c81"},
+    {file = "botocore-1.34.131-py3-none-any.whl", hash = "sha256:13b011d7b206ce00727dcee26548fa3b550db9046d5a0e90ac25a6e6c8fde6ef"},
+    {file = "botocore-1.34.131.tar.gz", hash = "sha256:502ddafe1d627fcf1e4c007c86454e5dd011dba7c58bd8e8a5368a79f3e387dc"},
 ]
 
 [package.dependencies]
@@ -705,13 +705,13 @@ testing = ["hatch", "pre-commit", "pytest", "tox"]
 
 [[package]]
 name = "faker"
-version = "25.8.0"
+version = "25.9.1"
 description = "Faker is a Python package that generates fake data for you."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "Faker-25.8.0-py3-none-any.whl", hash = "sha256:4c40b34a9c569018d4f9d6366d71a4da8a883d5ddf2b23197be5370f29b7e1b6"},
-    {file = "Faker-25.8.0.tar.gz", hash = "sha256:bdec5f2fb057d244ebef6e0ed318fea4dcbdf32c3a1a010766fc45f5d68fc68d"},
+    {file = "Faker-25.9.1-py3-none-any.whl", hash = "sha256:f1dc27dc8035cb7e97e96afbb5fe1305eed6aeea53374702cbac96acfe851626"},
+    {file = "Faker-25.9.1.tar.gz", hash = "sha256:0e1cf7a8d3c94de91a65ab1e9cf7050903efae1e97901f8e5924a9f45147ae44"},
 ]
 
 [package.dependencies]
@@ -846,42 +846,41 @@ files = [
 
 [[package]]
 name = "importlib-metadata"
-version = "7.1.0"
+version = "7.2.0"
 description = "Read metadata from Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "importlib_metadata-7.1.0-py3-none-any.whl", hash = "sha256:30962b96c0c223483ed6cc7280e7f0199feb01a0e40cfae4d4450fc6fab1f570"},
-    {file = "importlib_metadata-7.1.0.tar.gz", hash = "sha256:b78938b926ee8d5f020fc4772d487045805a55ddbad2ecf21c6d60938dc7fcd2"},
+    {file = "importlib_metadata-7.2.0-py3-none-any.whl", hash = "sha256:04e4aad329b8b948a5711d394fa8759cb80f009225441b4f2a02bd4d8e5f426c"},
+    {file = "importlib_metadata-7.2.0.tar.gz", hash = "sha256:3ff4519071ed42740522d494d04819b666541b9752c43012f85afb2cc220fcc6"},
 ]
 
 [package.dependencies]
 zipp = ">=0.5"
 
 [package.extras]
-docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
 perf = ["ipython"]
-testing = ["flufl.flake8", "importlib-resources (>=1.3)", "jaraco.test (>=5.4)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy", "pytest-perf (>=0.9.2)", "pytest-ruff (>=0.2.1)"]
+test = ["flufl.flake8", "importlib-resources (>=1.3)", "jaraco.test (>=5.4)", "packaging", "pyfakefs", "pytest (>=6,!=8.1.*)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy", "pytest-perf (>=0.9.2)", "pytest-ruff (>=0.2.1)"]
 
 [[package]]
 name = "inflect"
-version = "7.2.1"
+version = "7.3.0"
 description = "Correctly generate plurals, singular nouns, ordinals, indefinite articles"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "inflect-7.2.1-py3-none-any.whl", hash = "sha256:f4ecaffaeccbc746251d973c0674c47d63b262fdad63f651fb98e878eee1f449"},
-    {file = "inflect-7.2.1.tar.gz", hash = "sha256:a7ce5e23d6798734f256c1ad9ed52186b8ec276f10b18ce3d3ecb19c21eb6cb6"},
+    {file = "inflect-7.3.0-py3-none-any.whl", hash = "sha256:91f689dae31f9a0c28e6275f6161a0d39c7316524b71c5b6978920c7d362ce97"},
+    {file = "inflect-7.3.0.tar.gz", hash = "sha256:27264bb8992cab2be3c50772ecf7a79492c6f95e16e15002e6023001d2d639c2"},
 ]
 
 [package.dependencies]
 more-itertools = "*"
 typeguard = ">=4.0.1"
-typing-extensions = "*"
 
 [package.extras]
-docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-testing = ["pygments", "pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy", "pytest-ruff (>=0.2.1)"]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+test = ["pygments", "pytest (>=6,!=8.1.*)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy", "pytest-ruff (>=0.2.1)"]
 
 [[package]]
 name = "iniconfig"
@@ -2042,28 +2041,28 @@ jupyter = ["ipywidgets (>=7.5.1,<9)"]
 
 [[package]]
 name = "ruff"
-version = "0.4.9"
+version = "0.4.10"
 description = "An extremely fast Python linter and code formatter, written in Rust."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "ruff-0.4.9-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b262ed08d036ebe162123170b35703aaf9daffecb698cd367a8d585157732991"},
-    {file = "ruff-0.4.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:98ec2775fd2d856dc405635e5ee4ff177920f2141b8e2d9eb5bd6efd50e80317"},
-    {file = "ruff-0.4.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4555056049d46d8a381f746680db1c46e67ac3b00d714606304077682832998e"},
-    {file = "ruff-0.4.9-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e91175fbe48f8a2174c9aad70438fe9cb0a5732c4159b2a10a3565fea2d94cde"},
-    {file = "ruff-0.4.9-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0e8e7b95673f22e0efd3571fb5b0cf71a5eaaa3cc8a776584f3b2cc878e46bff"},
-    {file = "ruff-0.4.9-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:2d45ddc6d82e1190ea737341326ecbc9a61447ba331b0a8962869fcada758505"},
-    {file = "ruff-0.4.9-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:78de3fdb95c4af084087628132336772b1c5044f6e710739d440fc0bccf4d321"},
-    {file = "ruff-0.4.9-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:06b60f91bfa5514bb689b500a25ba48e897d18fea14dce14b48a0c40d1635893"},
-    {file = "ruff-0.4.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:88bffe9c6a454bf8529f9ab9091c99490578a593cc9f9822b7fc065ee0712a06"},
-    {file = "ruff-0.4.9-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:673bddb893f21ab47a8334c8e0ea7fd6598ecc8e698da75bcd12a7b9d0a3206e"},
-    {file = "ruff-0.4.9-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8c1aff58c31948cc66d0b22951aa19edb5af0a3af40c936340cd32a8b1ab7438"},
-    {file = "ruff-0.4.9-py3-none-musllinux_1_2_i686.whl", hash = "sha256:784d3ec9bd6493c3b720a0b76f741e6c2d7d44f6b2be87f5eef1ae8cc1d54c84"},
-    {file = "ruff-0.4.9-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:732dd550bfa5d85af8c3c6cbc47ba5b67c6aed8a89e2f011b908fc88f87649db"},
-    {file = "ruff-0.4.9-py3-none-win32.whl", hash = "sha256:8064590fd1a50dcf4909c268b0e7c2498253273309ad3d97e4a752bb9df4f521"},
-    {file = "ruff-0.4.9-py3-none-win_amd64.whl", hash = "sha256:e0a22c4157e53d006530c902107c7f550b9233e9706313ab57b892d7197d8e52"},
-    {file = "ruff-0.4.9-py3-none-win_arm64.whl", hash = "sha256:5d5460f789ccf4efd43f265a58538a2c24dbce15dbf560676e430375f20a8198"},
-    {file = "ruff-0.4.9.tar.gz", hash = "sha256:f1cb0828ac9533ba0135d148d214e284711ede33640465e706772645483427e3"},
+    {file = "ruff-0.4.10-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:5c2c4d0859305ac5a16310eec40e4e9a9dec5dcdfbe92697acd99624e8638dac"},
+    {file = "ruff-0.4.10-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a79489607d1495685cdd911a323a35871abfb7a95d4f98fc6f85e799227ac46e"},
+    {file = "ruff-0.4.10-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b1dd1681dfa90a41b8376a61af05cc4dc5ff32c8f14f5fe20dba9ff5deb80cd6"},
+    {file = "ruff-0.4.10-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c75c53bb79d71310dc79fb69eb4902fba804a81f374bc86a9b117a8d077a1784"},
+    {file = "ruff-0.4.10-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:18238c80ee3d9100d3535d8eb15a59c4a0753b45cc55f8bf38f38d6a597b9739"},
+    {file = "ruff-0.4.10-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:d8f71885bce242da344989cae08e263de29752f094233f932d4f5cfb4ef36a81"},
+    {file = "ruff-0.4.10-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:330421543bd3222cdfec481e8ff3460e8702ed1e58b494cf9d9e4bf90db52b9d"},
+    {file = "ruff-0.4.10-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e9b6fb3a37b772628415b00c4fc892f97954275394ed611056a4b8a2631365e"},
+    {file = "ruff-0.4.10-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f54c481b39a762d48f64d97351048e842861c6662d63ec599f67d515cb417f6"},
+    {file = "ruff-0.4.10-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:67fe086b433b965c22de0b4259ddfe6fa541c95bf418499bedb9ad5fb8d1c631"},
+    {file = "ruff-0.4.10-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:acfaaab59543382085f9eb51f8e87bac26bf96b164839955f244d07125a982ef"},
+    {file = "ruff-0.4.10-py3-none-musllinux_1_2_i686.whl", hash = "sha256:3cea07079962b2941244191569cf3a05541477286f5cafea638cd3aa94b56815"},
+    {file = "ruff-0.4.10-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:338a64ef0748f8c3a80d7f05785930f7965d71ca260904a9321d13be24b79695"},
+    {file = "ruff-0.4.10-py3-none-win32.whl", hash = "sha256:ffe3cd2f89cb54561c62e5fa20e8f182c0a444934bf430515a4b422f1ab7b7ca"},
+    {file = "ruff-0.4.10-py3-none-win_amd64.whl", hash = "sha256:67f67cef43c55ffc8cc59e8e0b97e9e60b4837c8f21e8ab5ffd5d66e196e25f7"},
+    {file = "ruff-0.4.10-py3-none-win_arm64.whl", hash = "sha256:dd1fcee327c20addac7916ca4e2653fbbf2e8388d8a6477ce5b4e986b68ae6c0"},
+    {file = "ruff-0.4.10.tar.gz", hash = "sha256:3aa4f2bc388a30d346c56524f7cacca85945ba124945fe489952aadb6b5cd804"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,6 @@
         "src/valentina/utils/discord_utils.py",
         "src/valentina/utils/errors.py",
         "src/valentina/utils/logging.py",
-        "src/valentina/utils/types.py",
         "src/valentina/views/*",
         "tests/*",
     ]

--- a/src/valentina/characters/add_from_sheet.py
+++ b/src/valentina/characters/add_from_sheet.py
@@ -12,7 +12,6 @@ from loguru import logger
 from valentina.constants import MAX_BUTTONS_PER_ROW, EmbedColor, TraitCategory
 from valentina.models import Campaign, Character, CharacterTrait, User
 from valentina.models.bot import ValentinaContext
-from valentina.utils import errors
 from valentina.utils.helpers import get_max_trait_value
 
 
@@ -180,12 +179,6 @@ class AddFromSheetWizard:
         # Add the character to the user's list of characters
         self.user.characters.append(self.character)
         await self.user.save()
-
-        # Make the user active if the user has no active character
-        try:
-            await self.user.active_character(self.ctx.guild)
-        except errors.NoActiveCharacterError:
-            await self.user.set_active_character(self.character)
 
         # Respond to the user
         embed = discord.Embed(

--- a/src/valentina/characters/add_from_sheet.py
+++ b/src/valentina/characters/add_from_sheet.py
@@ -170,7 +170,6 @@ class AddFromSheetWizard:
         # Associate the character with a campaign
         if self.campaign:
             self.character.campaign = str(self.campaign.id)
-            await self.campaign.create_channels(self.ctx)
 
         # Write the traits to the database
         self.character.traits = traits_to_add  # type: ignore [assignment]
@@ -179,6 +178,11 @@ class AddFromSheetWizard:
         # Add the character to the user's list of characters
         self.user.characters.append(self.character)
         await self.user.save()
+
+        # Create channel
+        if self.campaign:
+            await self.character.confirm_channel(self.ctx, self.campaign)
+            await self.campaign.sort_channels(self.ctx)
 
         # Respond to the user
         embed = discord.Embed(

--- a/src/valentina/characters/chargen.py
+++ b/src/valentina/characters/chargen.py
@@ -346,11 +346,16 @@ class RNGCharGen:
     """Randomly generate different parts of a character."""
 
     def __init__(
-        self, ctx: ValentinaContext, user: User, experience_level: RNGCharLevel = None
+        self,
+        ctx: ValentinaContext,
+        user: User,
+        experience_level: RNGCharLevel = None,
+        campaign: Campaign = None,
     ) -> None:
         self.ctx = ctx
         self.user = user
         self.experience_level = experience_level or RNGCharLevel.random_member()
+        self.campaign = campaign
 
     @staticmethod
     def _redistribute_trait_values(
@@ -486,6 +491,7 @@ class RNGCharGen:
             type_developer=developer_character,
             user_creator=self.user.id,
             user_owner=self.user.id,
+            campaign=str(self.campaign.id) if self.campaign else None,
         )
 
         await character.insert()
@@ -1278,7 +1284,8 @@ Once you select a character you can re-allocate dots and change the name, but yo
         if self.campaign:
             character.campaign = str(self.campaign.id)
             await character.save()
-            await self.campaign.create_channels(self.ctx)
+            await character.confirm_channel(self.ctx, self.campaign)
+            await self.campaign.sort_channels(self.ctx)
 
     async def spend_freebie_points(self, character: Character) -> Character:
         """Spend freebie points.

--- a/src/valentina/cogs/campaign.py
+++ b/src/valentina/cogs/campaign.py
@@ -32,7 +32,7 @@ from valentina.utils.converters import (
     ValidChapterNumber,
     ValidYYYYMMDD,
 )
-from valentina.utils.discord_utils import book_from_channel, campaign_from_channel
+from valentina.utils.discord_utils import fetch_channel_object
 from valentina.utils.helpers import truncate_string
 from valentina.views import (
     BookModal,
@@ -104,7 +104,8 @@ class CampaignCog(commands.Cog):
         if not await self.check_permissions(ctx):
             return
 
-        active_campaign = await ctx.fetch_active_campaign()
+        channel_objects = await fetch_channel_object(ctx, need_campaign=True)
+        campaign = channel_objects.campaign
 
         title = f"Move Chapter `{selected_chapter.name}` to book `{book.name}`"
         is_confirmed, interaction, confirmation_embed = await confirm_action(
@@ -125,9 +126,9 @@ class CampaignCog(commands.Cog):
         book.chapters.append(new_chapter)
         await book.save()
 
-        index = active_campaign.chapters.index(selected_chapter)
-        del active_campaign.chapters[index]
-        await active_campaign.save()
+        index = campaign.chapters.index(selected_chapter)
+        del campaign.chapters[index]
+        await campaign.save()
 
         await interaction.edit_original_response(embed=confirmation_embed, view=None)
 
@@ -166,12 +167,6 @@ class CampaignCog(commands.Cog):
         guild = await Guild.get(ctx.guild.id, fetch_links=True)
         guild.campaigns.append(campaign)
 
-        try:
-            test_var = guild.active_campaign.name  # noqa: F841
-        except AttributeError:
-            guild.active_campaign = campaign
-            logger.info(f"Set active campaign to `{campaign.name}`")
-
         await guild.save()
 
         await campaign.create_channels(ctx)
@@ -190,7 +185,8 @@ class CampaignCog(commands.Cog):
         ),
     ) -> None:
         """Set current date of a campaign."""
-        campaign = await campaign_from_channel(ctx) or await ctx.fetch_active_campaign()
+        channel_objects = await fetch_channel_object(ctx, need_campaign=True)
+        campaign = channel_objects.campaign
 
         campaign.date_in_game = date
         await campaign.save()
@@ -239,85 +235,13 @@ class CampaignCog(commands.Cog):
     @campaign.command(name="view", description="View a campaign")
     async def view_campaign(self, ctx: ValentinaContext) -> None:
         """View a campaign."""
-        campaign = await campaign_from_channel(ctx) or await ctx.fetch_active_campaign()
+        channel_objects = await fetch_channel_object(ctx, need_campaign=True)
+        campaign = channel_objects.campaign
 
         cv = CampaignViewer(ctx, campaign, max_chars=1000)
         paginator = await cv.display()
         await paginator.respond(ctx.interaction, ephemeral=True)
         await paginator.wait()
-
-    @campaign.command(name="set_active", description="Set a campaign as active")
-    async def campaign_set_active(
-        self,
-        ctx: ValentinaContext,
-        campaign: Option(
-            ValidCampaign,
-            description="Name of the campaign",
-            required=True,
-            autocomplete=select_campaign,
-        ),
-        hidden: Option(
-            bool,
-            description="Make the response visible only to you (default true).",
-            default=True,
-        ),
-    ) -> None:
-        """Set a campaign as active."""
-        if not await self.check_permissions(ctx):
-            return
-
-        title = f"Set campaign `{campaign.name}` as active"
-        is_confirmed, interaction, confirmation_embed = await confirm_action(
-            ctx, title, hidden=hidden, audit=True
-        )
-
-        if not is_confirmed:
-            return
-
-        guild = await Guild.get(ctx.guild.id, fetch_links=True)
-        guild.active_campaign = campaign
-        await guild.save()
-
-        await interaction.edit_original_response(embed=confirmation_embed, view=None)
-
-    @campaign.command(name="set_inactive", description="Set a campaign as inactive")
-    async def campaign_set_inactive(
-        self,
-        ctx: ValentinaContext,
-        hidden: Option(
-            bool,
-            description="Make the response visible only to you (default true).",
-            default=True,
-        ),
-    ) -> None:
-        """Set the active campaign as inactive."""
-        if not await self.check_permissions(ctx):
-            return
-
-        guild = await Guild.get(ctx.guild.id, fetch_links=True)
-        active_campaign = await guild.fetch_active_campaign()
-        if not active_campaign:
-            await present_embed(
-                ctx,
-                title="No active campaign",
-                description="There is no active campaign",
-                level="info",
-                ephemeral=hidden,
-            )
-            return
-
-        title = f"Set campaign `{active_campaign.name}` as inactive"
-        is_confirmed, interaction, confirmation_embed = await confirm_action(
-            ctx, title, hidden=hidden, audit=True
-        )
-
-        if not is_confirmed:
-            return
-
-        guild.active_campaign = None
-        await guild.save()
-
-        await interaction.edit_original_response(embed=confirmation_embed, view=None)
 
     @campaign.command(name="list", description="List all campaigns")
     async def campaign_list(
@@ -331,7 +255,6 @@ class CampaignCog(commands.Cog):
     ) -> None:
         """List all campaigns."""
         guild = await Guild.get(ctx.guild.id, fetch_links=True)
-        active_campaign = await guild.fetch_active_campaign()
 
         if len(guild.campaigns) == 0:
             await present_embed(
@@ -346,9 +269,7 @@ class CampaignCog(commands.Cog):
         text = f"## {len(guild.campaigns)} {p.plural_noun('campaign', len(guild.campaigns))} on `{ctx.guild.name}`\n"
         for c in sorted(guild.campaigns, key=lambda x: x.name):
             characters = await c.fetch_characters()
-            text += (
-                f"### **{c.name}** (Active)\n" if c == active_campaign else f"### **{c.name}**\n"
-            )
+            text += f"### **{c.name}**\n"
             text += f"{c.description}\n" if c.description else ""
             text += f"- `{len(c.books)}` {p.plural_noun('book', len(c.books))}\n"
             text += f"- `{len(c.npcs)}` NPCs\n"
@@ -371,7 +292,8 @@ class CampaignCog(commands.Cog):
         ),
     ) -> None:
         """Create a new NPC."""
-        active_campaign = await campaign_from_channel(ctx) or await ctx.fetch_active_campaign()
+        channel_objects = await fetch_channel_object(ctx, need_campaign=True)
+        campaign = channel_objects.campaign
 
         modal = NPCModal(title=truncate_string("Create new NPC", 45))
         await ctx.send_modal(modal)
@@ -384,13 +306,13 @@ class CampaignCog(commands.Cog):
         description = modal.description.strip()
 
         npc = CampaignNPC(name=name, npc_class=npc_class, description=description)
-        active_campaign.npcs.append(npc)
-        await active_campaign.save()
+        campaign.npcs.append(npc)
+        await campaign.save()
 
-        await ctx.post_to_audit_log(f"Create NPC: `{name}` in `{active_campaign.name}`")
+        await ctx.post_to_audit_log(f"Create NPC: `{name}` in `{campaign.name}`")
         await present_embed(
             ctx,
-            title=f"Create NPC: `{name}` in `{active_campaign.name}`",
+            title=f"Create NPC: `{name}` in `{campaign.name}`",
             level="success",
             fields=[
                 ("Class", npc_class),
@@ -416,9 +338,10 @@ class CampaignCog(commands.Cog):
         ),
     ) -> None:
         """List all NPCs."""
-        active_campaign = await campaign_from_channel(ctx) or await ctx.fetch_active_campaign()
+        channel_objects = await fetch_channel_object(ctx, need_campaign=True)
+        campaign = channel_objects.campaign
 
-        if len(active_campaign.npcs) == 0:
+        if len(campaign.npcs) == 0:
             await present_embed(
                 ctx,
                 title="No NPCs",
@@ -435,7 +358,7 @@ class CampaignCog(commands.Cog):
                     f"**__{npc.name}__**",
                     f"**Class:** {npc.npc_class}\n**Description:** {npc.description}",
                 )
-                for npc in sorted(active_campaign.npcs, key=lambda x: x.name)
+                for npc in sorted(campaign.npcs, key=lambda x: x.name)
             ]
         )
 
@@ -462,9 +385,11 @@ class CampaignCog(commands.Cog):
         if not await self.check_permissions(ctx):
             return
 
-        active_campaign = await campaign_from_channel(ctx) or await ctx.fetch_active_campaign()
+        channel_objects = await fetch_channel_object(ctx, need_campaign=True)
+        campaign = channel_objects.campaign
+
         try:
-            npc = active_campaign.npcs[index]
+            npc = campaign.npcs[index]
         except IndexError:
             await present_embed(
                 ctx,
@@ -485,15 +410,15 @@ class CampaignCog(commands.Cog):
         npc_class = modal.npc_class.strip().title()
         description = modal.description.strip()
 
-        active_campaign.npcs[index].name = name
-        active_campaign.npcs[index].npc_class = npc_class
-        active_campaign.npcs[index].description = description
-        await active_campaign.save()
+        campaign.npcs[index].name = name
+        campaign.npcs[index].npc_class = npc_class
+        campaign.npcs[index].description = description
+        await campaign.save()
 
-        await ctx.post_to_audit_log(f"Update NPC: `{name}` in `{active_campaign.name}`")
+        await ctx.post_to_audit_log(f"Update NPC: `{name}` in `{campaign.name}`")
         await present_embed(
             ctx,
-            title=f"Update NPC: `{name}` in `{active_campaign.name}`",
+            title=f"Update NPC: `{name}` in `{campaign.name}`",
             level="success",
             fields=[
                 ("Class", npc_class),
@@ -525,9 +450,11 @@ class CampaignCog(commands.Cog):
         if not await self.check_permissions(ctx):
             return
 
-        active_campaign = await campaign_from_channel(ctx) or await ctx.fetch_active_campaign()
+        channel_objects = await fetch_channel_object(ctx, need_campaign=True)
+        campaign = channel_objects.campaign
+
         try:
-            npc = active_campaign.npcs[index]
+            npc = campaign.npcs[index]
         except IndexError:
             await present_embed(
                 ctx,
@@ -538,7 +465,7 @@ class CampaignCog(commands.Cog):
             )
             return
 
-        title = f"Delete NPC: `{npc.name}` in `{active_campaign.name}`"
+        title = f"Delete NPC: `{npc.name}` in `{campaign.name}`"
         is_confirmed, interaction, confirmation_embed = await confirm_action(
             ctx, title, hidden=hidden, audit=True
         )
@@ -546,8 +473,8 @@ class CampaignCog(commands.Cog):
         if not is_confirmed:
             return
 
-        del active_campaign.npcs[index]
-        await active_campaign.save()
+        del campaign.npcs[index]
+        await campaign.save()
 
         await interaction.edit_original_response(embed=confirmation_embed, view=None)
 
@@ -567,7 +494,8 @@ class CampaignCog(commands.Cog):
         if not await self.check_permissions(ctx):
             return
 
-        active_campaign = await campaign_from_channel(ctx) or await ctx.fetch_active_campaign()
+        channel_objects = await fetch_channel_object(ctx, need_campaign=True)
+        campaign = channel_objects.campaign
 
         modal = BookModal(title=truncate_string("Create new book", 45))
         await ctx.send_modal(modal)
@@ -575,7 +503,7 @@ class CampaignCog(commands.Cog):
         if not modal.confirmed:
             return
 
-        books = await active_campaign.fetch_books()
+        books = await campaign.fetch_books()
 
         name = modal.name.strip().title()
         description_short = modal.description_short.strip()
@@ -587,19 +515,19 @@ class CampaignCog(commands.Cog):
             description_short=description_short,
             description_long=description_long,
             number=chapter_number,
-            campaign=str(active_campaign.id),
+            campaign=str(campaign.id),
         )
         await book.insert()
-        active_campaign.books.append(book)
-        await active_campaign.save()
-        await active_campaign.create_channels(ctx)
+        campaign.books.append(book)
+        await campaign.save()
+        await campaign.create_channels(ctx)
 
         await ctx.post_to_audit_log(
-            f"Create book: `{book.number}. {book.name}` in `{active_campaign.name}`",
+            f"Create book: `{book.number}. {book.name}` in `{campaign.name}`",
         )
         await present_embed(
             ctx,
-            f"Create book: `{book.number}. {book.name}` in `{active_campaign.name}`",
+            f"Create book: `{book.number}. {book.name}` in `{campaign.name}`",
             level="success",
             description=description_long,
             ephemeral=hidden,
@@ -616,8 +544,9 @@ class CampaignCog(commands.Cog):
         ),
     ) -> None:
         """List all books."""
-        active_campaign = await campaign_from_channel(ctx) or await ctx.fetch_active_campaign()
-        all_books = await active_campaign.fetch_books()
+        channel_objects = await fetch_channel_object(ctx, need_campaign=True)
+        campaign = channel_objects.campaign
+        all_books = await campaign.fetch_books()
 
         if len(all_books) == 0:
             await present_embed(
@@ -640,9 +569,7 @@ class CampaignCog(commands.Cog):
             ]
         )
 
-        await present_embed(
-            ctx, title=f"All Books in {active_campaign.name}", fields=fields, level="info"
-        )
+        await present_embed(ctx, title=f"All Books in {campaign.name}", fields=fields, level="info")
 
     @book.command(name="edit", description="Edit a book")
     @logger.catch
@@ -666,7 +593,8 @@ class CampaignCog(commands.Cog):
         if not await self.check_permissions(ctx):
             return
 
-        active_campaign = await campaign_from_channel(ctx) or await ctx.fetch_active_campaign()
+        channel_objects = await fetch_channel_object(ctx, need_campaign=True)
+        campaign = channel_objects.campaign
         original_name = book.name
 
         modal = BookModal(title=truncate_string(f"Edit book {book.name}", 45), book=book)
@@ -685,13 +613,13 @@ class CampaignCog(commands.Cog):
         await book.save()
 
         if original_name != name:
-            await active_campaign.create_channels(ctx)
+            await campaign.create_channels(ctx)
 
-        await ctx.post_to_audit_log(f"Update book: `{book.name}` in `{active_campaign.name}`")
+        await ctx.post_to_audit_log(f"Update book: `{book.name}` in `{campaign.name}`")
 
         await present_embed(
             ctx,
-            title=f"Update book: `{name}` in `{active_campaign.name}`",
+            title=f"Update book: `{name}` in `{campaign.name}`",
             level="success",
             description=description_short,
             ephemeral=hidden,
@@ -718,9 +646,10 @@ class CampaignCog(commands.Cog):
         if not await self.check_permissions(ctx):
             return
 
-        active_campaign = await campaign_from_channel(ctx) or await ctx.fetch_active_campaign()
+        channel_objects = await fetch_channel_object(ctx, need_campaign=True)
+        campaign = channel_objects.campaign
 
-        title = f"Delete book `{book.number}. {book.name}` from `{active_campaign.name}`"
+        title = f"Delete book `{book.number}. {book.name}` from `{campaign.name}`"
         is_confirmed, interaction, confirmation_embed = await confirm_action(
             ctx, title, hidden=hidden, audit=True
         )
@@ -729,8 +658,8 @@ class CampaignCog(commands.Cog):
             return
 
         await book.delete()
-        active_campaign.books.remove(book)
-        await active_campaign.save()
+        campaign.books.remove(book)
+        await campaign.save()
 
         await interaction.edit_original_response(embed=confirmation_embed, view=None)
 
@@ -771,7 +700,9 @@ class CampaignCog(commands.Cog):
             )
             return
 
-        active_campaign = await campaign_from_channel(ctx) or await ctx.fetch_active_campaign()
+        channel_objects = await fetch_channel_object(ctx, need_campaign=True)
+        campaign = channel_objects.campaign
+
         original_number = book.number
 
         title = (
@@ -784,7 +715,7 @@ class CampaignCog(commands.Cog):
         if not is_confirmed:
             return
 
-        all_books = await active_campaign.fetch_books()
+        all_books = await campaign.fetch_books()
 
         # Update the number of the selected book
         book.number = new_number
@@ -805,7 +736,7 @@ class CampaignCog(commands.Cog):
 
         # Save the selected book with its new number
         await book.save()
-        await active_campaign.create_channels(ctx)
+        await campaign.create_channels(ctx)
 
         await interaction.edit_original_response(embed=confirmation_embed, view=None)
 
@@ -825,7 +756,8 @@ class CampaignCog(commands.Cog):
         if not await self.check_permissions(ctx):
             return
 
-        book = await book_from_channel(ctx)
+        channel_objects = await fetch_channel_object(ctx, need_book=True)
+        book = channel_objects.book
         if not book:
             await present_embed(
                 ctx,
@@ -880,7 +812,8 @@ class CampaignCog(commands.Cog):
         ),
     ) -> None:
         """List all chapters."""
-        book = await book_from_channel(ctx)
+        channel_objects = await fetch_channel_object(ctx, need_book=True)
+        book = channel_objects.book
         if not book:
             await present_embed(
                 ctx,
@@ -938,7 +871,8 @@ class CampaignCog(commands.Cog):
         if not await self.check_permissions(ctx):
             return
 
-        book = await book_from_channel(ctx)
+        channel_objects = await fetch_channel_object(ctx, need_book=True)
+        book = channel_objects.book
         if not book:
             await present_embed(
                 ctx,
@@ -995,7 +929,8 @@ class CampaignCog(commands.Cog):
         if not await self.check_permissions(ctx):
             return
 
-        book = await book_from_channel(ctx)
+        channel_objects = await fetch_channel_object(ctx, need_book=True)
+        book = channel_objects.book
         if not book:
             await present_embed(
                 ctx,
@@ -1047,7 +982,8 @@ class CampaignCog(commands.Cog):
         if not await self.check_permissions(ctx):
             return
 
-        book = await book_from_channel(ctx)
+        channel_objects = await fetch_channel_object(ctx, need_book=True)
+        book = channel_objects.book
         if not book:
             await present_embed(
                 ctx,

--- a/src/valentina/cogs/developer.py
+++ b/src/valentina/cogs/developer.py
@@ -218,10 +218,6 @@ class Developer(commands.Cog):
             user.characters.append(character)
             await user.save()
 
-            # Make the user active if the user has no active character
-            if str(ctx.guild.id) not in user.active_characters:
-                await user.set_active_character(character)
-
             # Associate the character with a campaign
             campaign = random.choice(created_campaigns)
             character.campaign = str(campaign.id)
@@ -232,12 +228,6 @@ class Developer(commands.Cog):
         for campaign in created_campaigns:
             await campaign.create_channels(ctx)
             guild.campaigns.append(campaign)
-
-        try:
-            test_var = guild.active_campaign.name  # noqa: F841
-        except AttributeError:
-            guild.active_campaign = campaign
-            logger.debug(f"Set active campaign to `{campaign.name}`")
 
         await guild.save()
 

--- a/src/valentina/cogs/experience.py
+++ b/src/valentina/cogs/experience.py
@@ -14,7 +14,7 @@ from valentina.utils.converters import (
     ValidCharacterObject,
     ValidCharTrait,
 )
-from valentina.utils.discord_utils import campaign_from_channel
+from valentina.utils.discord_utils import fetch_channel_object
 from valentina.utils.helpers import get_trait_multiplier, get_trait_new_value
 from valentina.views import confirm_action, present_embed
 
@@ -62,7 +62,8 @@ class Experience(commands.Cog):
             )
             return
 
-        active_campaign = await campaign_from_channel(ctx) or await ctx.fetch_active_campaign()
+        channel_objects = await fetch_channel_object(ctx, need_campaign=True)
+        campaign = channel_objects.campaign
 
         title = f"Add `{amount}` xp to `{user.name}`"
         description = "View experience with `/user_info`"
@@ -73,7 +74,7 @@ class Experience(commands.Cog):
             return
 
         # Make the database updates
-        await user.add_campaign_xp(active_campaign, amount)
+        await user.add_campaign_xp(campaign, amount)
 
         # Send the confirmation message
         await msg.edit_original_response(embed=confirmation_embed, view=None)
@@ -111,7 +112,8 @@ class Experience(commands.Cog):
             )
             return
 
-        active_campaign = await campaign_from_channel(ctx) or await ctx.fetch_active_campaign()
+        channel_objects = await fetch_channel_object(ctx, need_campaign=True)
+        campaign = channel_objects.campaign
 
         title = f"Add `{amount}` cool {p.plural_noun('point', amount)} to `{user.name}`"
         description = "View cool points with `/user_info`"
@@ -122,7 +124,7 @@ class Experience(commands.Cog):
             return
 
         # Make the database updates
-        await user.add_campaign_cool_points(active_campaign, amount)
+        await user.add_campaign_cool_points(campaign, amount)
 
         # Send the confirmation message
         await msg.edit_original_response(embed=confirmation_embed, view=None)
@@ -190,9 +192,10 @@ class Experience(commands.Cog):
 
         # Make the updates
         user = await User.get(ctx.author.id)
-        active_campaign = await campaign_from_channel(ctx) or await ctx.fetch_active_campaign()
+        channel_objects = await fetch_channel_object(ctx, need_campaign=True)
+        campaign = channel_objects.campaign
 
-        await user.spend_campaign_xp(active_campaign, upgrade_cost)
+        await user.spend_campaign_xp(campaign, upgrade_cost)
         trait.value = new_trait_value
         await trait.save()
 

--- a/src/valentina/cogs/gameplay.py
+++ b/src/valentina/cogs/gameplay.py
@@ -80,6 +80,7 @@ class Roll(commands.Cog):
             pool,
             difficulty,
             DiceType.D10.value,
+            campaign,
             comment,
             character=character,
             desperation_pool=desperation,
@@ -145,6 +146,7 @@ class Roll(commands.Cog):
             pool,
             difficulty,
             DiceType.D10.value,
+            campaign,
             comment,
             trait_one=trait_one,
             trait_two=trait_two,
@@ -168,7 +170,9 @@ class Roll(commands.Cog):
             dice_size (int): The number of sides on the dice
             pool (int): The number of dice to roll
         """
-        await perform_roll(ctx, pool, 0, dice_size, comment)
+        channel_objects = await fetch_channel_object(ctx, need_campaign=True)
+        campaign = channel_objects.campaign
+        await perform_roll(ctx, pool, 0, dice_size, campaign, comment)
 
     @roll.command(name="macro", description="Roll a macro")
     async def roll_macro(
@@ -233,6 +237,7 @@ class Roll(commands.Cog):
             pool,
             difficulty,
             DiceType.D10.value,
+            campaign,
             comment,
             trait_one=trait_one,
             trait_two=trait_two,
@@ -278,6 +283,7 @@ class Roll(commands.Cog):
             0,
             difficulty,
             DiceType.D10.value,
+            campaign,
             comment,
             character=character,
             desperation_pool=desperation,

--- a/src/valentina/cogs/inventory.py
+++ b/src/valentina/cogs/inventory.py
@@ -10,7 +10,7 @@ from valentina.models import InventoryItem
 from valentina.models.bot import Valentina, ValentinaContext
 from valentina.utils.autocomplete import select_char_inventory_item
 from valentina.utils.converters import ValidInventoryItemFromID
-from valentina.utils.discord_utils import character_from_channel
+from valentina.utils.discord_utils import fetch_channel_object
 from valentina.utils.helpers import truncate_string
 from valentina.views import InventoryItemModal, confirm_action, present_embed
 
@@ -29,7 +29,9 @@ class InventoryCog(commands.Cog, name="Inventory"):
         ctx: ValentinaContext,
     ) -> None:
         """List all items in a character's inventory."""
-        character = await character_from_channel(ctx) or await ctx.fetch_active_character()
+        channel_objects = await fetch_channel_object(ctx, need_character=True)
+        character = channel_objects.character
+
         items = await InventoryItem.find(InventoryItem.character == str(character.id)).to_list()
 
         description = ""
@@ -65,7 +67,9 @@ class InventoryCog(commands.Cog, name="Inventory"):
         ),
     ) -> None:
         """Add an item to a character's inventory."""
-        character = await character_from_channel(ctx) or await ctx.fetch_active_character()
+        channel_objects = await fetch_channel_object(ctx, need_character=True)
+        character = channel_objects.character
+
         modal = InventoryItemModal(title=truncate_string(f"Add inventory to {character.name}", 45))
         await ctx.send_modal(modal)
         await modal.wait()
@@ -99,7 +103,9 @@ class InventoryCog(commands.Cog, name="Inventory"):
         ),
     ) -> None:
         """Edit an item in a character's inventory."""
-        character = await character_from_channel(ctx) or await ctx.fetch_active_character()
+        channel_objects = await fetch_channel_object(ctx, need_character=True)
+        character = channel_objects.character
+
         modal = InventoryItemModal(
             title=truncate_string(f"Edit {item.name}", 45),
             item_name=item.name,
@@ -132,7 +138,8 @@ class InventoryCog(commands.Cog, name="Inventory"):
         ),
     ) -> None:
         """Edit an item in a character's inventory."""
-        character = await character_from_channel(ctx) or await ctx.fetch_active_character()
+        channel_objects = await fetch_channel_object(ctx, need_character=True)
+        character = channel_objects.character
 
         title = f"Delete `{item.name}` from `{character.name}`'s inventory"
         is_confirmed, msg, confirmation_embed = await confirm_action(

--- a/src/valentina/cogs/storyteller.py
+++ b/src/valentina/cogs/storyteller.py
@@ -43,7 +43,7 @@ from valentina.utils.converters import (
     ValidImageURL,
     ValidTraitCategory,
 )
-from valentina.utils.discord_utils import campaign_from_channel
+from valentina.utils.discord_utils import fetch_channel_object
 from valentina.utils.helpers import (
     fetch_data_from_url,
 )
@@ -93,7 +93,8 @@ class StoryTeller(commands.Cog):
     @storyteller.command(name="set_danger", description="Set the danger level")
     async def set_danger(self, ctx: ValentinaContext, danger: int) -> None:
         """Set the danger level for a campaign."""
-        campaign = await campaign_from_channel(ctx) or await ctx.fetch_active_campaign()
+        channel_objects = await fetch_channel_object(ctx, need_campaign=True)
+        campaign = channel_objects.campaign
 
         title = f"Set danger level to {danger}"
         is_confirmed, interaction, confirmation_embed = await confirm_action(ctx, title, audit=True)
@@ -109,7 +110,8 @@ class StoryTeller(commands.Cog):
     @storyteller.command(name="set_desperation", description="Set the desperation level")
     async def set_desperation(self, ctx: ValentinaContext, desperation: int) -> None:
         """Set the desperation level for a campaign."""
-        campaign = await campaign_from_channel(ctx) or await ctx.fetch_active_campaign()
+        channel_objects = await fetch_channel_object(ctx, need_campaign=True)
+        campaign = channel_objects.campaign
 
         title = f"Set desperation level to {desperation}"
         is_confirmed, interaction, confirmation_embed = await confirm_action(ctx, title, audit=True)

--- a/src/valentina/cogs/storyteller.py
+++ b/src/valentina/cogs/storyteller.py
@@ -159,6 +159,9 @@ class StoryTeller(commands.Cog):
             )
             return
 
+        channel_objects = await fetch_channel_object(ctx, need_campaign=True)
+        campaign = channel_objects.campaign
+
         user = await User.get(ctx.author.id, fetch_links=True)
         character = Character(
             guild=ctx.guild.id,
@@ -170,6 +173,7 @@ class StoryTeller(commands.Cog):
             type_storyteller=True,
             user_creator=user.id,
             user_owner=user.id,
+            campaign=str(campaign.id),
         )
 
         wizard = AddFromSheetWizard(ctx, character=character, user=user)
@@ -237,8 +241,11 @@ class StoryTeller(commands.Cog):
             )
             return
 
+        channel_objects = await fetch_channel_object(ctx, need_campaign=True)
+        campaign = channel_objects.campaign
+
         user = await User.get(ctx.author.id, fetch_links=True)
-        chargen = RNGCharGen(ctx, user, experience_level=level)
+        chargen = RNGCharGen(ctx, user, experience_level=level, campaign=campaign)
         character = await chargen.generate_full_character(
             char_class=character_class,
             storyteller_character=True,
@@ -617,7 +624,7 @@ class StoryTeller(commands.Cog):
         character.user_owner = new_owner.id
         await character.save()
 
-        await character.update_channel(ctx, campaign)
+        await character.update_channel_permissions(ctx, campaign)
 
         await interaction.edit_original_response(embed=confirmation_embed, view=None)
 

--- a/src/valentina/cogs/storyteller.py
+++ b/src/valentina/cogs/storyteller.py
@@ -586,6 +586,9 @@ class StoryTeller(commands.Cog):
         ),
     ) -> None:
         """Update the value of a trait for a storyteller or player character."""
+        channel_objects = await fetch_channel_object(ctx, need_campaign=True)
+        campaign = channel_objects.campaign
+
         old_owner = await User.get(character.user_owner, fetch_links=True)
         new_owner = await User.get(new_user.id, fetch_links=True)
 
@@ -613,6 +616,8 @@ class StoryTeller(commands.Cog):
 
         character.user_owner = new_owner.id
         await character.save()
+
+        await character.update_channel(ctx, campaign)
 
         await interaction.edit_original_response(embed=confirmation_embed, view=None)
 
@@ -705,6 +710,9 @@ class StoryTeller(commands.Cog):
         ),
     ) -> None:
         """Roll traits for a storyteller character."""
+        channel_objects = await fetch_channel_object(ctx, need_campaign=True)
+        campaign = channel_objects.campaign
+
         pool = trait_one.value + trait_two.value
 
         await perform_roll(
@@ -712,6 +720,7 @@ class StoryTeller(commands.Cog):
             pool,
             difficulty,
             DiceType.D10.value,
+            campaign,
             comment,
             trait_one=trait_one,
             trait_two=trait_two,

--- a/src/valentina/constants.py
+++ b/src/valentina/constants.py
@@ -41,49 +41,6 @@ VALID_IMAGE_EXTENSIONS = frozenset(["png", "jpg", "jpeg", "gif", "webp"])
 
 
 ### ENUMS ###
-class LogLevel(StrEnum):
-    """Enum for logging levels."""
-
-    TRACE = "TRACE"
-    DEBUG = "DEBUG"
-    INFO = "INFO"
-    WARNING = "WARNING"
-    SUCCESS = "SUCCESS"
-    ERROR = "ERROR"
-    CRITICAL = "CRITICAL"
-
-
-class ChannelPermission(Enum):
-    """Enum for permissions when creating a character. Default is UNRESTRICTED."""
-
-    DEFAULT = 0  # Default
-    HIDDEN = 1
-    READ_ONLY = 2
-    POST = 3
-    MANAGE = 4
-
-
-class DiceType(Enum):
-    """Enum for types of dice."""
-
-    D4 = 4
-    D6 = 6
-    D8 = 8
-    D10 = 10
-    D100 = 100
-
-
-class EmbedColor(Enum):
-    """Enum for colors of embeds."""
-
-    SUCCESS = 0x00FF00  # GREEN
-    ERROR = 0xFF0000  # RED
-    WARNING = 0xFF5F00  # ORANGE
-    INFO = 0x00FFFF  # CYAN
-    DEBUG = 0x0000FF  # BLUE
-    DEFAULT = 0x6082B6  # GRAY
-    GRAY = 0x808080
-    YELLOW = 0xFFFF00
 
 
 class Emoji(Enum):
@@ -126,6 +83,58 @@ class Emoji(Enum):
     WARNING = "⚠️"
     WEREWOLF = "🐺"
     YES = "✅"
+
+
+class LogLevel(StrEnum):
+    """Enum for logging levels."""
+
+    TRACE = "TRACE"
+    DEBUG = "DEBUG"
+    INFO = "INFO"
+    WARNING = "WARNING"
+    SUCCESS = "SUCCESS"
+    ERROR = "ERROR"
+    CRITICAL = "CRITICAL"
+
+
+class ChannelPermission(Enum):
+    """Enum for permissions when creating a character. Default is UNRESTRICTED."""
+
+    DEFAULT = 0  # Default
+    HIDDEN = 1
+    READ_ONLY = 2
+    POST = 3
+    MANAGE = 4
+
+
+class CampaignChannelName(Enum):
+    """Enum for common campaign channel names."""
+
+    GENERAL = f"{Emoji.SPARKLES.value}-general"
+    STORYTELLER = f"{Emoji.LOCK.value}-storyteller"
+
+
+class DiceType(Enum):
+    """Enum for types of dice."""
+
+    D4 = 4
+    D6 = 6
+    D8 = 8
+    D10 = 10
+    D100 = 100
+
+
+class EmbedColor(Enum):
+    """Enum for colors of embeds."""
+
+    SUCCESS = 0x00FF00  # GREEN
+    ERROR = 0xFF0000  # RED
+    WARNING = 0xFF5F00  # ORANGE
+    INFO = 0x00FFFF  # CYAN
+    DEBUG = 0x0000FF  # BLUE
+    DEFAULT = 0x6082B6  # GRAY
+    GRAY = 0x808080
+    YELLOW = 0xFFFF00
 
 
 class GithubIssueLabels(Enum):

--- a/src/valentina/dataclasses.py
+++ b/src/valentina/dataclasses.py
@@ -1,0 +1,30 @@
+"""Dataclasses for Valentina app."""
+
+from dataclasses import dataclass
+
+from valentina.models import Campaign, CampaignBook, Character
+
+
+@dataclass
+class ChannelObjects:
+    """Dataclass for Channel Objects."""
+
+    campaign: Campaign | None
+    book: CampaignBook | None
+    character: Character | None
+
+    def __bool__(self) -> bool:
+        """Return True if any of the objects are present."""
+        return any([self.campaign, self.book, self.character])
+
+    def has_book(self) -> bool:
+        """Return True if the object has a book."""
+        return bool(self.book)
+
+    def has_character(self) -> bool:
+        """Return True if the object has a character."""
+        return bool(self.character)
+
+    def has_campaign(self) -> bool:
+        """Return True if the object has a campaign."""
+        return bool(self.campaign)

--- a/src/valentina/models/bot.py
+++ b/src/valentina/models/bot.py
@@ -412,34 +412,6 @@ class ValentinaContext(discord.ApplicationContext):
 
         return channel
 
-    async def fetch_active_character(self, raise_error: bool = True) -> Character | None:
-        """Fetch the active character for the user.
-
-        Args:
-            raise_error (bool, optional): Whether to raise an error if no active character is found. Defaults to True. Returns None if False.
-
-        Returns:
-            Character | None: The active character for the user or None if no active character is found.
-        """
-        user = await User.get(self.author.id, fetch_links=True)
-        return await user.active_character(self.guild, raise_error=raise_error)
-
-    async def fetch_active_campaign(self, raise_error: bool = True) -> Campaign:
-        """Fetch the active campaign for the user.
-
-        Args:
-            raise_error (bool, optional): Whether to raise an error if no active campaign is found. Defaults to True. Returns None if False.
-
-        Returns:
-            Campaign: The active campaign for the user.
-        """
-        guild = await Guild.get(self.guild.id, fetch_links=True)
-        campaign = guild.active_campaign
-        if not campaign and raise_error:
-            raise errors.NoActiveCampaignError
-
-        return campaign
-
 
 class Valentina(commands.Bot):
     """Subclass discord.Bot."""

--- a/src/valentina/models/campaign.py
+++ b/src/valentina/models/campaign.py
@@ -19,7 +19,7 @@ from beanie import (
 from loguru import logger
 from pydantic import BaseModel, Field
 
-from valentina.constants import CHANNEL_PERMISSIONS, Emoji
+from valentina.constants import CHANNEL_PERMISSIONS, CampaignChannelName, Emoji
 from valentina.utils.helpers import time_now
 
 from .character import Character
@@ -261,8 +261,8 @@ class Campaign(Document):
         """Create the campaign channels in the guild."""
         # Static channels
         common_channel_list = {  # channel_db_key: channel_name
-            "channel_storyteller": f"{Emoji.LOCK.value}-storyteller",
-            "channel_general": f"{Emoji.SPARKLES.value}-general",
+            "channel_storyteller": CampaignChannelName.STORYTELLER.value,
+            "channel_general": CampaignChannelName.GENERAL.value,
         }
         for channel_db_key, channel_name in common_channel_list.items():
             # Set permissions

--- a/src/valentina/models/campaign.py
+++ b/src/valentina/models/campaign.py
@@ -83,6 +83,11 @@ class CampaignBook(Document):
     number: int
     notes: list[Link[Note]] = Field(default_factory=list)
 
+    @property
+    def channel_name(self) -> str:
+        """Channel name for the book."""
+        return f"{Emoji.BOOK.value}-{self.number:0>2}-{self.name.lower().replace(' ', '-')}"
+
     async def fetch_chapters(self) -> list[CampaignBookChapter]:
         """Fetch all chapters in the book."""
         return sorted(
@@ -108,6 +113,70 @@ class CampaignBook(Document):
         self.channel = None
         await self.save()
 
+    async def confirm_channel(
+        self, ctx: "ValentinaContext", campaign: Optional["Campaign"]
+    ) -> discord.TextChannel | None:
+        """Confirm the channel for the book.
+
+        Args:
+            ctx (ValentinaContext): The context of the command.
+            campaign (Campaign, optional): The campaign object.
+
+        Returns:
+            discord.TextChannel | None: The channel object
+        """
+        campaign = campaign or await Campaign.get(self.campaign)
+        if not campaign:
+            return None
+
+        category, channels = await campaign.fetch_campaign_category_channels(ctx)
+
+        if not category:
+            return None
+
+        is_channel_name_in_category = any(self.channel_name == channel.name for channel in channels)
+        is_channel_id_in_category = (
+            any(self.channel == channel.id for channel in channels) if self.channel else False
+        )
+
+        # If channel name exists in category but not in database, add channel id to self
+        if is_channel_name_in_category and not self.channel:
+            await asyncio.sleep(1)  # Keep the rate limit happy
+            for channel in channels:
+                if channel.name == self.channel_name:
+                    self.channel = channel.id
+                    await self.save()
+                    return channel
+
+        # If channel.id exists but has wrong name, rename it
+        elif self.channel and is_channel_id_in_category and not is_channel_name_in_category:
+            channel_object = next(
+                (channel for channel in channels if self.channel == channel.id), None
+            )
+            return await ctx.channel_update_or_add(
+                channel=channel_object,
+                name=self.channel_name,
+                category=category,
+                permissions=CHANNEL_PERMISSIONS["default"],
+                topic=f"Channel for book {self.number}. {self.name}",
+            )
+
+        # If channel does not exist, create it
+        elif not is_channel_name_in_category:
+            await asyncio.sleep(1)  # Keep the rate limit happy
+            book_channel = await ctx.channel_update_or_add(
+                name=self.channel_name,
+                category=category,
+                permissions=CHANNEL_PERMISSIONS["default"],
+                topic=f"Channel for Chapter {self.number}. {self.name}",
+            )
+            self.channel = book_channel.id
+            await self.save()
+            return book_channel
+
+        await asyncio.sleep(1)  # Keep the rate limit happy
+        return discord.utils.get(channels, name=self.channel_name)
+
 
 class Campaign(Document):
     """Represents a campaign in the database."""
@@ -132,64 +201,6 @@ class Campaign(Document):
     async def update_modified_date(self) -> None:
         """Update the date_modified field."""
         self.date_modified = time_now()
-
-    async def _confirm_book_channels(
-        self,
-        ctx: "ValentinaContext",
-        category: discord.CategoryChannel,
-        channels: list[discord.TextChannel],
-    ) -> None:  # pragma: no cover
-        """Create the book channels for the campaign."""
-        for book in await self.fetch_books():
-            channel_name = (
-                f"{Emoji.BOOK.value}-{book.number:0>2}-{book.name.lower().replace(' ', '-')}"
-            )
-            channel_db_id = book.channel
-            channel_name_in_category = any(channel_name == channel.name for channel in channels)
-            channel_id_in_category = (
-                any(channel_db_id == channel.id for channel in channels) if channel_db_id else False
-            )
-
-            if channel_name_in_category and not channel_db_id:
-                await asyncio.sleep(1)  # Keep the rate limit happy
-                for channel in channels:
-                    if channel.name == channel_name:
-                        book.channel = channel.id
-                        await book.save()
-                logger.info(
-                    f"Channel {channel_name} exists in {category} but not in database. Add channel id to database."
-                )
-            elif channel_db_id and channel_id_in_category and not channel_name_in_category:
-                await asyncio.sleep(1)  # Keep the rate limit happy
-                channel_object = next(
-                    (channel for channel in channels if channel_db_id == channel.id), None
-                )
-
-                await ctx.channel_update_or_add(
-                    channel=channel_object,
-                    name=channel_name,
-                    category=category,
-                    permissions=CHANNEL_PERMISSIONS["default"],
-                    topic=f"Channel for book {book.number}. {book.name}",
-                )
-
-                logger.info(
-                    f"Channel {channel_name} exists in database and {category} but name is different. Renamed channel."
-                )
-
-            elif not channel_name_in_category:
-                await asyncio.sleep(1)  # Keep the rate limit happy
-                created_channel = await ctx.channel_update_or_add(
-                    name=channel_name,
-                    category=category,
-                    permissions=CHANNEL_PERMISSIONS["default"],
-                    topic=f"Channel for Chapter {book.number}. {book.name}",
-                )
-                book.channel = created_channel.id
-                await book.save()
-                logger.info(
-                    f"Channel {channel_name} does not exist in {category}. Create new channel and add to database"
-                )
 
     async def _confirm_character_channels(
         self,
@@ -318,6 +329,16 @@ class Campaign(Document):
                     f"Channel {channel_name} does not exist in {category}. Create new channel and add to database"
                 )
 
+    async def fetch_campaign_category_channels(
+        self, ctx: "ValentinaContext"
+    ) -> tuple[discord.CategoryChannel, list[discord.TextChannel]]:
+        """Fetch the campaign category channels in the guild."""
+        for category, channels in ctx.guild.by_category():
+            if category and category.id == self.channel_campaign_category:
+                return category, channels
+
+        return None, []
+
     @staticmethod
     def _custom_channel_sort(channel: discord.TextChannel) -> tuple[int, str]:  # pragma: no cover
         """Custom sorting key to for campaign channels.
@@ -337,7 +358,13 @@ class Campaign(Document):
         if channel.name.startswith(Emoji.LOCK.value):
             return (2, channel.name)
 
-        return (3, channel.name)
+        if channel.name.startswith(Emoji.SILHOUETTE.value):
+            return (3, channel.name)
+
+        if channel.name.startswith(Emoji.DEAD.value):
+            return (4, channel.name)
+
+        return (5, channel.name)
 
     async def create_channels(self, ctx: "ValentinaContext") -> None:  # pragma: no cover
         """Create the campaign channels in the guild."""
@@ -369,23 +396,19 @@ class Campaign(Document):
             if category and category.id == self.channel_campaign_category:
                 await self._confirm_common_channels(ctx, category=category, channels=channels)
                 await asyncio.sleep(1)  # Keep the rate limit happy
-                await self._confirm_book_channels(ctx, category=category, channels=channels)
-                await asyncio.sleep(1)  # Keep the rate limit happy
-                await self._confirm_character_channels(ctx, category=category, channels=channels)
-                await asyncio.sleep(1)  # Keep the rate limit happy
+
+                for book in await self.fetch_books():
+                    await book.confirm_channel(ctx, campaign=self)
+                    await asyncio.sleep(1)  # Keep the rate limit happy
+
+                for character in await self.fetch_characters():
+                    await character.confirm_channel(ctx, campaign=self)
+                    await asyncio.sleep(1)  # Keep the rate limit happy
                 break
 
-        for category, channels in ctx.guild.by_category():
-            if category and category.id == self.channel_campaign_category:
-                sorted_channels = sorted(channels, key=self._custom_channel_sort)
-                for i, channel in enumerate(sorted_channels):
-                    await channel.edit(position=i)
-                    await asyncio.sleep(2)  # Keep the rate limit happy
+        await self.sort_channels(ctx)
 
-                logger.debug(f"Sorted channels: {[channel.name for channel in sorted_channels]}")
-                break
-
-        logger.debug(f"All channels confirmed for campaign '{self.name}' in '{ctx.guild.name}'")
+        logger.info(f"All channels confirmed for campaign '{self.name}' in '{ctx.guild.name}'")
 
     async def delete_channels(self, ctx: "ValentinaContext") -> None:  # pragma: no cover
         """Delete the channel associated with the book.
@@ -423,8 +446,11 @@ class Campaign(Document):
         await self.save()
 
     async def fetch_characters(self) -> list[Character]:
-        """Fetch all characters in the campaign."""
-        return await Character.find(Character.campaign == str(self.id)).to_list()
+        """Fetch all player characters in the campaign."""
+        return await Character.find(
+            Character.campaign == str(self.id),
+            Character.type_player == True,  # noqa: E712
+        ).to_list()
 
     async def fetch_books(self) -> list[CampaignBook]:
         """Fetch all books in the campaign."""
@@ -432,3 +458,23 @@ class Campaign(Document):
             self.books,  # type: ignore [arg-type]
             key=lambda x: x.number,
         )
+
+    async def sort_channels(self, ctx: "ValentinaContext") -> None:
+        """Sort the campaign channels in the guild.
+
+        Args:
+            ctx (ValentinaContext): The context of the command.
+        """
+        for category, channels in ctx.guild.by_category():
+            if category and category.id == self.channel_campaign_category:
+                sorted_channels = sorted(channels, key=self._custom_channel_sort)
+                for i, channel in enumerate(sorted_channels):
+                    if channel.position and channel.position == i:
+                        continue
+                    await channel.edit(position=i)
+                    await asyncio.sleep(2)  # Keep the rate limit happy
+
+                logger.debug(f"Sorted channels: {[channel.name for channel in sorted_channels]}")
+                break
+
+        logger.info(f"Channels sorted for campaign '{self.name}' in '{ctx.guild.name}'")

--- a/src/valentina/models/character.py
+++ b/src/valentina/models/character.py
@@ -331,7 +331,7 @@ class Character(Document):
 
     async def update_channel(
         self, ctx: "ValentinaContext", campaign: "Campaign"
-    ) -> discord.TextChannel | None:
+    ) -> discord.TextChannel | None:  # pragma: no cover
         """Update the permissions for the character's channel."""
         if not self.channel:
             return None

--- a/src/valentina/models/character.py
+++ b/src/valentina/models/character.py
@@ -22,6 +22,7 @@ from valentina.constants import (
     CHANNEL_PERMISSIONS,
     CharacterConcept,
     CharClass,
+    Emoji,
     HunterCreed,
     TraitCategory,
     VampireClan,
@@ -327,3 +328,27 @@ class Character(Document):
                 return trait
 
         return None
+
+    async def update_channel(
+        self, ctx: "ValentinaContext", campaign: "Campaign"
+    ) -> discord.TextChannel | None:
+        """Update the permissions for the character's channel."""
+        if not self.channel:
+            return None
+
+        channel = ctx.guild.get_channel(self.channel)
+        channel_name = f"{Emoji.SILHOUETTE.value}-{self.name.lower().replace(' ', '-')}"
+        owned_by_user = discord.utils.get(ctx.bot.users, id=self.user_owner)
+        category = discord.utils.get(ctx.guild.categories, id=campaign.channel_campaign_category)
+
+        if not channel:
+            return None
+
+        return await ctx.channel_update_or_add(
+            channel=channel,
+            name=channel_name,
+            category=category,
+            permissions=CHANNEL_PERMISSIONS["campaign_character_channel"],
+            permissions_user_post=owned_by_user,
+            topic=f"Character channel for {self.name}",
+        )

--- a/src/valentina/models/errors.py
+++ b/src/valentina/models/errors.py
@@ -50,10 +50,8 @@ class ErrorReporter:
         # Reported to users but suppressed from logs and traceback
         if isinstance(
             error,
-            errors.NoActiveCampaignError
-            | errors.ValidationError
+            errors.ValidationError
             | errors.ChannelTypeError
-            | errors.NoActiveCharacterError
             | errors.NotEnoughExperienceError
             | errors.NoExperienceInCampaignError
             | errors.URLNotAvailableError

--- a/src/valentina/models/guild.py
+++ b/src/valentina/models/guild.py
@@ -67,7 +67,6 @@ class Guild(Document):
 
     id: int  # type: ignore [assignment]
 
-    active_campaign: Link["Campaign"] = None
     campaigns: list[Link["Campaign"]] = Field(default_factory=list)
     changelog_posted_version: str | None = None
     channels: GuildChannels = GuildChannels()
@@ -165,23 +164,12 @@ class Guild(Document):
         await create_player_role(guild)
         logger.debug(f"GUILD: Roles created/updated on {self.name}")
 
-    async def fetch_active_campaign(self) -> "Campaign":
-        """Fetch the active campaign for the guild."""
-        try:
-            return await Campaign.get(self.active_campaign.id, fetch_links=True)  # type: ignore [attr-defined]
-        except AttributeError as e:
-            raise errors.NoActiveCampaignError from e
-
     async def delete_campaign(self, campaign: "Campaign") -> None:
         """Delete a campaign from the guild. Remove the campaign from the guild's list of campaigns and delete the campaign from the database.
 
         Args:
             campaign (Campaign): The campaign to delete.
         """
-        # Remove the campaign from the active campaign if it is active
-        if self.active_campaign and self.active_campaign == campaign:
-            self.active_campaign = None
-
         if campaign in self.campaigns:
             self.campaigns.remove(campaign)
 

--- a/src/valentina/models/note.py
+++ b/src/valentina/models/note.py
@@ -30,7 +30,7 @@ class Note(Document):
     text: str
     parent_id: str  # campaign_id, book_id, or character_id
 
-    @before_event(Insert, Replace, Save, Update, SaveChanges)
+    @before_event(Insert, Replace, Save, Update, SaveChanges)  # pragma: no cover
     async def update_modified_date(self) -> None:
         """Update the date_modified field."""
         self.date_modified = time_now()

--- a/src/valentina/typed_dicts.py
+++ b/src/valentina/typed_dicts.py
@@ -3,8 +3,9 @@
 
 from typing import TypedDict
 
-
 ### TypedDicts ###
+
+
 class HunterCreedDict(TypedDict):
     """Type for Hunter Creed sub-dictionary."""
 

--- a/src/valentina/utils/discord_utils.py
+++ b/src/valentina/utils/discord_utils.py
@@ -212,9 +212,6 @@ async def fetch_channel_object(
     book = await CampaignBook.find_one(CampaignBook.channel == discord_channel.id, fetch_links=True)
     character = await Character.find_one(Character.channel == discord_channel.id, fetch_links=True)
 
-    if raise_error and not campaign and not book and not character:
-        raise errors.ChannelTypeError
-
     if raise_error and need_character and not character:
         msg = "Rerun command in a character channel."
         raise errors.ChannelTypeError(msg)
@@ -226,5 +223,8 @@ async def fetch_channel_object(
     if raise_error and need_book and not book:
         msg = "Rerun command in a book channel"
         raise errors.ChannelTypeError(msg)
+
+    if raise_error and not campaign and not book and not character:
+        raise errors.ChannelTypeError
 
     return ChannelObjects(campaign=campaign, book=book, character=character)

--- a/src/valentina/utils/discord_utils.py
+++ b/src/valentina/utils/discord_utils.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from valentina.models.bot import ValentinaContext
 
 
-async def assert_permissions(ctx: "ValentinaContext", **permissions: bool) -> None:  # noqa: RUF029
+async def assert_permissions(ctx: "ValentinaContext", **permissions: bool) -> None:  # noqa: RUF029 # pragma: no cover
     """Check if the bot has the required permissions to run the command."""
     if missing := [
         perm for perm, value in permissions.items() if getattr(ctx.app_permissions, perm) != value
@@ -25,7 +25,7 @@ async def assert_permissions(ctx: "ValentinaContext", **permissions: bool) -> No
         raise BotMissingPermissionsError(missing)
 
 
-async def create_storyteller_role(guild: discord.Guild) -> discord.Role:
+async def create_storyteller_role(guild: discord.Guild) -> discord.Role:  # pragma: no cover
     """Create a storyteller role for the guild."""
     storyteller = discord.utils.get(guild.roles, name="Storyteller")
 
@@ -72,7 +72,7 @@ async def create_storyteller_role(guild: discord.Guild) -> discord.Role:
     return storyteller
 
 
-async def create_player_role(guild: discord.Guild) -> discord.Role:
+async def create_player_role(guild: discord.Guild) -> discord.Role:  # pragma: no cover
     """Create player role for the guild."""
     player = discord.utils.get(guild.roles, name="Player", mentionable=True, hoist=True)
 

--- a/src/valentina/utils/errors.py
+++ b/src/valentina/utils/errors.py
@@ -90,42 +90,6 @@ class MessageTooLongError(Exception):
         super().__init__(msg, *args, **kwargs)
 
 
-class NoActiveCharacterError(Exception):
-    """Raised when a no active character is found."""
-
-    def __init__(
-        self,
-        msg: str | None = None,
-        e: Exception | None = None,
-        *args: str | int,
-        **kwargs: int | str | bool,
-    ):
-        if not msg:
-            msg = "No active character found\nUse `/character set_active`"
-        if e:
-            msg += f"\nRaised from: {e.__class__.__name__}: {e}"
-
-        super().__init__(msg, *args, **kwargs)
-
-
-class NoActiveCampaignError(Exception):
-    """Raised when a no active campaign is found."""
-
-    def __init__(
-        self,
-        msg: str | None = None,
-        e: Exception | None = None,
-        *args: str | int,
-        **kwargs: int | str | bool,
-    ):
-        if not msg:
-            msg = "No active campaign found\nUse `/campaign set_active`"
-        if e:
-            msg += f"\nRaised from: {e.__class__.__name__}: {e}"
-
-        super().__init__(msg, *args, **kwargs)
-
-
 class NoCharacterClassError(Exception):
     """Raised when a character's class is not a valid CharClass enum value."""
 

--- a/src/valentina/utils/perform_roll.py
+++ b/src/valentina/utils/perform_roll.py
@@ -3,9 +3,8 @@
 import discord
 
 from valentina.constants import EmbedColor, Emoji
-from valentina.models import Character, CharacterTrait, DiceRoll
+from valentina.models import Campaign, Character, CharacterTrait, DiceRoll
 from valentina.models.bot import ValentinaContext
-from valentina.utils.discord_utils import fetch_channel_object
 from valentina.views import ReRollButton, RollDisplay
 
 
@@ -14,6 +13,7 @@ async def perform_roll(  # pragma: no cover
     pool: int,
     difficulty: int,
     dice_size: int,
+    campaign: Campaign,
     comment: str | None = None,
     hidden: bool = False,
     trait_one: CharacterTrait | None = None,
@@ -28,6 +28,7 @@ async def perform_roll(  # pragma: no cover
         pool (int): The number of dice to roll.
         difficulty (int): The difficulty of the roll.
         dice_size (int): The size of the dice.
+        campaign (Campaign): The campaign to log the roll for.
         comment (str, optional): A comment to display with the roll. Defaults to None.
         hidden (bool, optional): Whether to hide the response from other users. Defaults to False.
         from_macro (bool, optional): Whether the roll is from a macro. Defaults to False.
@@ -72,10 +73,6 @@ async def perform_roll(  # pragma: no cover
     await view.wait()
 
     if view.overreach:
-        # TODO: This is a temporary solution for grabbing the campaign object.
-        channel_objects = await fetch_channel_object(ctx, need_campaign=True)
-        campaign = channel_objects.campaign
-
         if campaign.danger < 5:  # noqa: PLR2004
             campaign.danger += 1
             await campaign.save()
@@ -111,6 +108,7 @@ async def perform_roll(  # pragma: no cover
             pool=pool,
             difficulty=difficulty,
             dice_size=dice_size,
+            campaign=campaign,
             comment=comment,
             hidden=hidden,
             trait_one=trait_one,

--- a/tests/cogs/test_experience_cog.py
+++ b/tests/cogs/test_experience_cog.py
@@ -22,7 +22,6 @@ async def test_xp_add(async_mock_ctx1, mock_bot, user_factory, campaign_factory)
     # GIVEN a mock context, a user, and a campaign
     user = user_factory.build(
         id=async_mock_ctx1.author.id,
-        active_characters={},
         characters=[],
         campaign_experience={},
         macros=[],
@@ -31,9 +30,6 @@ async def test_xp_add(async_mock_ctx1, mock_bot, user_factory, campaign_factory)
 
     campaign = campaign_factory.build()
     await campaign.insert()
-
-    # MOCK call to fetch_active_campaign
-    async_mock_ctx1.fetch_active_campaign = AsyncMock(return_value=campaign)
 
     # WHEN the xp_add command is called
     cog = Experience(bot=mock_bot)
@@ -56,7 +52,6 @@ async def test_cp_add(async_mock_ctx1, mock_bot, user_factory, campaign_factory)
     # GIVEN a mock context, a user, and a campaign
     user = user_factory.build(
         id=async_mock_ctx1.author.id,
-        active_characters={},
         characters=[],
         campaign_experience={},
         macros=[],
@@ -65,9 +60,6 @@ async def test_cp_add(async_mock_ctx1, mock_bot, user_factory, campaign_factory)
 
     campaign = campaign_factory.build()
     await campaign.insert()
-
-    # MOCK call to fetch_active_campaign
-    async_mock_ctx1.fetch_active_campaign = AsyncMock(return_value=campaign)
 
     # WHEN the xp_add command is called
     await Experience(bot=mock_bot).cp_add(
@@ -101,7 +93,6 @@ async def test_xp_spend(
 
     user = user_factory.build(
         id=async_mock_ctx1.author.id,
-        active_characters={},
         characters=[],
         campaign_experience={
             str(campaign.id): CampaignExperience(xp_current=30, xp_total=30, cool_points=1)
@@ -109,9 +100,6 @@ async def test_xp_spend(
         macros=[],
     )
     await user.insert()
-
-    # MOCK call to fetch_active_campaign
-    async_mock_ctx1.fetch_active_campaign = AsyncMock(return_value=campaign)
 
     # WHEN the xp_add command is called
     await Experience(bot=mock_bot).xp_spend(
@@ -147,7 +135,6 @@ async def test_xp_spend_not_enough_xp(
 
     user = user_factory.build(
         id=async_mock_ctx1.author.id,
-        active_characters={},
         characters=[],
         campaign_experience={
             str(campaign.id): CampaignExperience(xp_current=10, xp_total=30, cool_points=1)
@@ -155,9 +142,6 @@ async def test_xp_spend_not_enough_xp(
         macros=[],
     )
     await user.insert()
-
-    # MOCK call to fetch_active_campaign
-    async_mock_ctx1.fetch_active_campaign = AsyncMock(return_value=campaign)
 
     # WHEN the xp_add command is called
     with pytest.raises(errors.NotEnoughExperienceError):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,13 @@ from motor.motor_asyncio import AsyncIOMotorClient
 from valentina.utils import ValentinaConfig, console
 from valentina.utils.database import init_database
 
+### Constants for Testing ###
+CHANNEL_CHARACTER_ID = 1234567890
+CHANNEL_BOOK_ID = 1234567891
+CHANNEL_CATEGORY_CAMPAIGN_ID = 1234567892
 
+
+## Database initialization ##
 @pytest_asyncio.fixture(autouse=True)
 async def _init_database(request):
     """Initialize the database."""
@@ -49,22 +55,61 @@ def mock_bot(mocker):
 
 
 @pytest.fixture()
-def mock_discord_channel(mocker):
-    """A mock of a discord.Channel object."""
+def mock_discord_campaign_category_channel(mocker):
+    """A mock of a discord.CategoryChannel object associated with a campaign."""
     mock_channel = mocker.MagicMock()
-    mock_channel.id = 12345
-    mock_channel.__class__ = discord.TextChannel
+    mock_channel.id = CHANNEL_CATEGORY_CAMPAIGN_ID
+    mock_channel.__class__ = discord.CategoryChannel
     return mock_channel
 
 
 @pytest.fixture()
-def mock_interaction1(mocker, mock_guild1, mock_member, mock_discord_channel):
-    """A mock of a discord.Interaction object."""
+def mock_discord_unassociated_category_channel(mocker):
+    """A mock of a discord.CategoryChannel object associated with a campaign."""
+    mock_channel = mocker.MagicMock()
+    mock_channel.id = 2000001
+    mock_channel.__class__ = discord.CategoryChannel
+    return mock_channel
+
+
+@pytest.fixture()
+def mock_discord_unassociated_channel(mocker, mock_discord_unassociated_category_channel):
+    """A mock of a discord.Channel object associated with a book."""
+    mock_channel = mocker.MagicMock()
+    mock_channel.id = 1000002
+    mock_channel.__class__ = discord.TextChannel
+    mock_channel.category = mock_discord_unassociated_category_channel
+    return mock_channel
+
+
+@pytest.fixture()
+def mock_discord_character_channel(mocker, mock_discord_campaign_category_channel):
+    """A mock of a discord.Channel object associated with a character."""
+    mock_channel = mocker.MagicMock()
+    mock_channel.id = CHANNEL_CHARACTER_ID
+    mock_channel.__class__ = discord.TextChannel
+    mock_channel.category = mock_discord_campaign_category_channel
+    return mock_channel
+
+
+@pytest.fixture()
+def mock_discord_book_channel(mocker, mock_discord_campaign_category_channel):
+    """A mock of a discord.Channel object associated with a book."""
+    mock_channel = mocker.MagicMock()
+    mock_channel.id = CHANNEL_BOOK_ID
+    mock_channel.__class__ = discord.TextChannel
+    mock_channel.category = mock_discord_campaign_category_channel
+    return mock_channel
+
+
+@pytest.fixture()
+def mock_interaction1(mocker, mock_guild1, mock_member, mock_discord_character_channel):
+    """A mock of a discord.Interaction object run in a character channel."""
     mock_interaction = mocker.MagicMock()
     mock_interaction.id = 1
     mock_interaction.guild = mock_guild1
     mock_interaction.author = mock_member
-    mock_interaction.channel = mock_discord_channel
+    mock_interaction.channel = mock_discord_character_channel
 
     mock_interaction.__class__ = discord.Interaction
 
@@ -150,9 +195,9 @@ def mock_guild2(mocker):
 
 @pytest_asyncio.fixture()
 async def async_mock_ctx1(  # noqa: RUF029
-    mocker, mock_member, mock_guild1, mock_interaction1, mock_discord_channel
+    mocker, mock_member, mock_guild1, mock_interaction1, mock_discord_character_channel
 ):
-    """Create an async mock context object with user 1."""
+    """Create an async mock context object with user 1 run in a character channel."""
     mock_bot = mocker.AsyncMock()
     mock_bot.__class__ = commands.Bot
 
@@ -166,7 +211,7 @@ async def async_mock_ctx1(  # noqa: RUF029
     mock_ctx.author = mock_member
     mock_ctx.bot = mock_bot
     mock_ctx.guild = mock_guild1
-    mock_ctx.channel = mock_discord_channel
+    mock_ctx.channel = mock_discord_character_channel
     mock_ctx.__class__ = discord.ApplicationContext
 
     # Mock the methods which post to audit and error logs
@@ -183,8 +228,8 @@ async def async_mock_ctx1(  # noqa: RUF029
 
 
 @pytest.fixture()
-def mock_ctx1(mocker, mock_member, mock_guild1, mock_interaction1, mock_discord_channel):
-    """Create a mock context object with user 1."""
+def mock_ctx1(mocker, mock_member, mock_guild1, mock_interaction1, mock_discord_character_channel):
+    """Create a mock context object with user 1 run in a character channel."""
     # Mock the ctx.bot object
     mock_bot = mocker.MagicMock()
     mock_bot.__class__ = commands.Bot
@@ -199,7 +244,7 @@ def mock_ctx1(mocker, mock_member, mock_guild1, mock_interaction1, mock_discord_
     mock_ctx.author = mock_member
     mock_ctx.bot = mock_bot
     mock_ctx.guild = mock_guild1
-    mock_ctx.channel = mock_discord_channel
+    mock_ctx.channel = mock_discord_character_channel
     mock_ctx.__class__ = discord.ApplicationContext
 
     return mock_ctx

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -35,6 +35,8 @@ from valentina.models import (
     UserMacro,
 )
 
+from .conftest import CHANNEL_BOOK_ID, CHANNEL_CATEGORY_CAMPAIGN_ID, CHANNEL_CHARACTER_ID
+
 
 @register_fixture
 class RollStatFactory(BeanieDocumentFactory[CharacterTrait]):
@@ -99,7 +101,7 @@ class BookFactory(BeanieDocumentFactory[CampaignBook]):
 
     @classmethod
     def channel(cls) -> GuildChannels:
-        return 12345
+        return CHANNEL_BOOK_ID
 
     @classmethod
     def number(cls) -> str:
@@ -132,6 +134,10 @@ class CampaignFactory(BeanieDocumentFactory[Campaign]):
     __min_collection_length__ = 1
     __max_collection_length__ = 3
     __randomize_collection_length__ = True
+
+    @classmethod
+    def channel_campaign_category(cls) -> GuildChannels:
+        return CHANNEL_CATEGORY_CAMPAIGN_ID
 
     @classmethod
     def name(cls) -> str:
@@ -232,6 +238,10 @@ class CharacterFactory(BeanieDocumentFactory[Character]):
     __max_collection_length__ = 3
     __randomize_collection_length__ = True
     __set_as_default_factory_for_type__ = True
+
+    @classmethod
+    def channel(cls) -> GuildChannels:
+        return CHANNEL_CHARACTER_ID
 
     @classmethod
     def char_class_name(cls) -> str:

--- a/tests/models/test_guild_model.py
+++ b/tests/models/test_guild_model.py
@@ -13,7 +13,7 @@ from valentina.utils import errors
 async def test_add_roll_result_thumbnail(mock_ctx1, guild_factory):
     """Test the add_roll_result_thumbnail method."""
     # GIVEN a guild
-    guild = guild_factory.build(roll_result_thumbnails=[], active_campaign=None, campaigns=[])
+    guild = guild_factory.build(roll_result_thumbnails=[], campaigns=[])
     await guild.insert()
 
     # WHEN adding a thumbnail
@@ -60,46 +60,20 @@ async def test_fetch_diceroll_thumbnail(guild_factory):
     assert found_new_thumbnail
 
 
-async def test_fetch_active_campaign(campaign_factory, guild_factory):
-    """Test the fetch_active_campaign method."""
-    # GIVEN a guild with a campaign
-    guild = guild_factory.build(
-        roll_result_thumbnails=[],
-        active_campaign=None,
-        campaigns=[],
-    )
-    campaign = campaign_factory.build(guild=guild.id, characters=[])
-    await campaign.insert()
-
-    with pytest.raises(errors.NoActiveCampaignError):
-        active_campaign = await guild.fetch_active_campaign()
-
-    # GIVEN an active campaign
-    guild.active_campaign = campaign
-
-    # WHEN fetching the active campaign
-    active_campaign = await guild.fetch_active_campaign()
-
-    # THEN the correct campaign is returned
-    assert active_campaign.id == campaign.id
-
-
 @pytest.mark.drop_db()
 async def test_delete_campaign(campaign_factory, guild_factory):
     """Test the delete_campaign method."""
     # GIVEN a guild with a campaign
-    guild = guild_factory.build(active_campaign=None, campaigns=[])
+    guild = guild_factory.build(campaigns=[])
     campaign = campaign_factory.build(guild=guild.id, characters=[])
     await campaign.insert()
 
     guild.campaigns.append(campaign)
-    guild.active_campaign = campaign
 
     # WHEN deleting the campaign
     await guild.delete_campaign(campaign)
 
     # THEN the active campaign is deleted
-    assert guild.active_campaign is None
     assert guild.campaigns == []
     assert not await Campaign.find(Campaign.is_deleted == False).to_list()  # noqa: E712
     assert campaign.is_deleted

--- a/tests/utils/test_converters.py
+++ b/tests/utils/test_converters.py
@@ -196,8 +196,11 @@ async def test_valid_yyyymmdd():
 
 
 @pytest.mark.drop_db()
-async def test_valid_chapter_number(mock_ctx1, book_chapter_factory, book_factory):
+async def test_valid_chapter_number(
+    mock_ctx1, book_chapter_factory, book_factory, mock_discord_book_channel
+):
     """Test the ValidChapterNumber converter."""
+    mock_ctx1.channel = mock_discord_book_channel
     chapter = book_chapter_factory.build()
     chapter_object = await chapter.insert()
 
@@ -225,7 +228,7 @@ async def test_valid_chapter_number(mock_ctx1, book_chapter_factory, book_factor
 
 
 @pytest.mark.drop_db()
-async def test_campaign_chapter_converter(mock_ctx1, guild_factory, campaign_factory):
+async def test_campaign_chapter_converter(mock_ctx1, campaign_factory):
     """Test the CampaignChapterConverter converter.
 
     TODO: Remove this after chapter migration
@@ -241,13 +244,6 @@ async def test_campaign_chapter_converter(mock_ctx1, guild_factory, campaign_fac
     campaign = campaign_factory.build(guild=mock_ctx1.guild.id, chapters=[chapter], characters=[])
     await campaign.insert()
 
-    guild = guild_factory.build(
-        id=mock_ctx1.guild.id,
-        campaigns=[campaign],
-        active_campaign=campaign,
-        roll_result_thumbnails=[],
-    )
-    await guild.insert()
     # WHEN the converter is called with a valid chapter number
     # THEN assert the result is the correct number
     assert await CampaignChapterConverter().convert(mock_ctx1, 1) == chapter
@@ -264,21 +260,13 @@ async def test_campaign_chapter_converter(mock_ctx1, guild_factory, campaign_fac
 
 
 @pytest.mark.drop_db()
-async def test_valid_book_number(mock_ctx1, guild_factory, campaign_factory, book_factory):
+async def test_valid_book_number(mock_ctx1, campaign_factory, book_factory):
     """Test the ValidBookNumber converter."""
     book = book_factory.build()
     book_object = await book.insert()
 
     campaign = campaign_factory.build(guild=mock_ctx1.guild.id, books=[book_object], characters=[])
     await campaign.insert()
-
-    guild = guild_factory.build(
-        id=mock_ctx1.guild.id,
-        campaigns=[campaign],
-        active_campaign=campaign,
-        roll_result_thumbnails=[],
-    )
-    await guild.insert()
 
     # WHEN the converter is called with a valid chapter number
     # THEN assert the result is the correct number

--- a/user_guide.md
+++ b/user_guide.md
@@ -34,15 +34,16 @@ For interactive help, run `/help commands` to see a list of available commands.
 Valentina Noir revolves around three core concepts:
 
 -   **Characters**: Player characters managed in Valentina allow for quick dice rolling, XP spending, and character updates.
--   **Campaigns**: Storylines with multiple chapters, characters, NPCs, and notes, spanning multiple gaming sessions.
+-   **Campaigns**: Storylines with multiple chapters, characters, NPCs, and notes, spanning multiple gaming sessions. Every campaign has its own set of channels which are used for all gameplay.
 -   **Gameplay**: The actual game, where you roll dice and play using your character.
 
 ## 3. CHARACTER CREATION & MANAGEMENT
 
 ### Creating a Character
 
+-   Go to the `✨-general` channel within the campaign.
 -   Use `/character add` to add a new character you've already created by hand.
--   User `/character create` to create use a RNG guided character creation process.
+-   Use `/character create` to create use a RNG guided character creation process.
 -   **IMPORTANT**: If using `/character add`, create your character on paper before entering it into Valentina.
 -   **Post creation:** Don't worry if you make a mistake or the section on your sheet doesn't appear during character generation.You can easily rename your character, add/update traits, abilities, custom sections, and a biography as needed.
 
@@ -82,7 +83,7 @@ Macros are a powerful tool to enhance your gaming experience, allowing for quick
 -   **Roll Dice**: Use `/roll` for various types of rolls, including stats, traits, macros, D10s, or arbitrary dice.
 -   **Create Campaign NPCs**: As you meet an important NPC, take a note of them with `/campaign npc create`.
 -   **Add Campaign Notes**: Keep track of important information by creating notes during gameplay with `/campaign note create`.
--   **Determine damage**: Use `/gameplay damage [damage]` to determine the effects of damage.
+-   **Determine damage**: Use `/roll damage [damage]` to determine the effects of damage.
 
 ### Dice Rolling
 


### PR DESCRIPTION
Remove concept of active characters and campaigns. Use automatically generated channels for all interactions which require a character, campaign, or book.